### PR TITLE
Improve readme with reference to docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,13 +65,13 @@ docker-wagtail-develop_web_1        /bin/bash -c cd /code/wagt ...   Up      0.0
 You can open a django shell session
 
 ```sh
-docker exec -it docker-wagtail-develop_web_1 python manage.py shell
+docker-compose exec web python manage.py shell
 ```
 
 You can open a shell on the web server
 
 ```sh
-docker exec -it docker-wagtail-develop_web_1 bash
+docker-compose exec web bash
 ```
 
 


### PR DESCRIPTION
As pointed out in #5 there are some inconsistencies with naming of the services.

This documents how to use `docker-compose exec <service_name>` instead of `docker exec`