### PR TITLE
Add Linux support

### DIFF
--- a/docker-compose.linux.yml
+++ b/docker-compose.linux.yml
@@ -1,0 +1,9 @@
+version: '3'
+
+services:
+  web:
+    user: ${CURRENT_UID}
+
+  frontend:
+    user: ${CURRENT_UID}
+


### PR DESCRIPTION
This package works almost flawlessly on Linux, except when it comes to the web container accessing files built by another container, they are not properly copied and the CMS-admin-view renders with missing assets. I did some digging and the problem here is ownership, the files built from the container are owned by root, while the rest are owned by my user.

When I run the containers with my own user defined as user everything works as expected.

So in this PR I created a separate `docker-compose.yml` that you can run together with the `docker-compose.yml` file called `docker-compose.linux.yml`, where “user” are set for each container.

You run it like this (tested on Ubuntu):

```
CURRENT_UID=$(id -u):$(id -g) docker-compose -f docker-compose.yml -f docker-compose.linux.yml up
```

There might be more effective ways of achieving this, but it’s a start :) Any thoughts?