### PR TITLE
remove node-sass rebuild from Dockerfile.frontend

### DIFF
--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -6,5 +6,3 @@ COPY ./wagtail/package.json ./package.json
 RUN npm i npm@latest -g
 RUN npm --prefix / install
 RUN npm install npm-run-all gulp webpack /
-RUN node /node_modules/node-sass/scripts/install.js
-RUN npm rebuild node-sass


### PR DESCRIPTION
* native modules no longer used for sass so no rebuild required (adoption of `dart-sass`)
* https://github.com/wagtail/wagtail/pull/6033
* https://github.com/wagtail/wagtail/commit/7eeb44ad0408cf72060f19db577de2159859cd74