### PR TITLE
Automate setting up bakerydemo to use the Postgres db in services

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,9 @@ cd ~/Development
 git clone git@github.com:wagtail/docker-wagtail-develop.git wagtail-dev
 # 3. Move inside the new folder.
 cd wagtail-dev/
-# 4. Run the setup script. This will check out all the dependency repos.
+# 4. Run the setup script. This will check out the bakerydemo project and local copies of wagtail and its dependencies.
 ./setup.sh
-# 5. Configure your app to use PostgreSQL via the DATABASE_URL from docker-compose.yml
-cp bakerydemo/bakerydemo/settings/local.py.docker-compose-example bakerydemo/bakerydemo/settings/local.py
-echo "DJANGO_SETTINGS_MODULE=bakerydemo.settings.local" > bakerydemo/.env
-# 6. Build the containers
+# 5. Build the containers
 docker-compose build
 ```
 
@@ -40,52 +37,23 @@ Here is the resulting folder structure:
 └── bakerydemo    # Wagtail Bakery project used for development.
 ```
 
-Once setup is over,
+Once the build is complete:
 
 ```sh
-# 7. Start your container setup
+# 6. Start your containers and wait for them to finish their startup scripts.
 docker-compose up
+# 7. Now in a new shell, run the databse setup script. The database will be persisted across container executions by Docker's Volumes system so you will only need to run this commmand the first time you start the database.
+setup-db.sh
 # Success!
 ```
-
-- Visit your site at http://localhost:8000
-- The admin interface is at http://localhost:8000/admin/ - log in with `admin` / `changeme`.
-
-### Debugging
 
 If you're running this on Linux you might get into some privilege issues that can be solved using this command (tested on Ubuntu):
 ```sh
 CURRENT_UID=$(id -u):$(id -g) docker-compose -f docker-compose.yml -f docker-compose.linux.yml up
 ```
 
-#### Debugging data migrations / data loading
-
-Sometimes there are model changes in Wagtail that require migrations to be created in the bakerydemo project. If so, you may see errors like the example below:
-
-```
-web_1       |   Applying wagtailusers.0009_userprofile_verbose_name_plural... OK
-db_1        | 2020-08-01 17:45:49.722 UTC [54] ERROR:  column base_formfield.clean_name does not exist at character 58
-db_1        | 2020-08-01 17:45:49.722 UTC [54] STATEMENT:  SELECT COUNT(*) AS "__count" FROM "base_formfield" WHERE "base_formfield"."clean_name" = ''
-db_1        | 2020-08-01 17:45:50.195 UTC [54] ERROR:  column "clean_name" of relation "base_formfield" does not exist at character 47
-web_1       | Traceback (most recent call last):
-web_1       |   File "/usr/local/lib/python3.7/site-packages/django/db/backends/utils.py", line 86, in _execute
-web_1       |     return self.cursor.execute(sql, params)
-web_1       | psycopg2.errors.UndefinedColumn: column "clean_name" of relation "base_formfield" does not exist
-web_1       | LINE 1: UPDATE "base_formfield" SET "sort_order" = 0, "clean_name" =...
-```
-
-To fix this, open a new terminal window, exec into the container and run makemigrations:
-
-```
-# In the root of your wagtail-dev project folder:
-docker exec -it wagtail-dev_web_1 /bin/bash
-
-# then, at the prompt inside the container:
-./manage.py makemigrations
-./manage.py migrate
-```
-
-Errors in the migrations will prevent docker-compose from loading the initial data. So, return to your original terminal window, stop the server (with CONTROL-C), and rerun `docker-compose up`.
+- Visit your site at http://localhost:8000
+- The admin interface is at http://localhost:8000/admin/ - log in with `admin` / `changeme`.
 
 What you can do
 ---------------
@@ -94,11 +62,11 @@ What you can do
 
 ```sh
 $ docker-compose ps
-              Name                             Command               State           Ports
----------------------------------------------------------------------------------------------------
-docker-wagtail-develop_db_1         docker-entrypoint.sh postgres    Up      5432/tcp
-docker-wagtail-develop_frontend_1   /bin/sh -c cp -r /node_mod ...   Up
-docker-wagtail-develop_web_1        /bin/bash -c cd /code/wagt ...   Up      0.0.0.0:8000->8000/tcp
+  Name                Command               State           Ports
+--------------------------------------------------------------------------
+db         docker-entrypoint.sh postgres    Up          5432/tcp
+frontend   docker-entrypoint.sh /bin/ ...   Up
+web        ./manage.py runserver 0.0. ...   Up          0.0.0.0:8000->8000/tcp
 ```
 
 ### You can open a django shell session

--- a/README.md
+++ b/README.md
@@ -77,11 +77,15 @@ web_1       | LINE 1: UPDATE "base_formfield" SET "sort_order" = 0, "clean_name"
 To fix this, open a new terminal window, exec into the container and run makemigrations:
 
 ```
-docker exec -it wagtail-dev_web_1 /bin/bash`
-`./manage.py makemigrations`
+# In the root of your wagtail-dev project folder:
+docker exec -it wagtail-dev_web_1 /bin/bash
+
+# then, at the prompt inside the container:
+./manage.py makemigrations
+./manage.py migrate
 ```
 
-Then, back in your original terminal window, stop the server (with CONTROL-C), and rerun `docker-compose up`.
+Errors in the migrations will prevent docker-compose from loading the initial data. So, return to your original terminal window, stop the server (with CONTROL-C), and rerun `docker-compose up`.
 
 What you can do
 ---------------

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     ports:
       - "8000:8000"
     environment:
-      DATABASE_URL: postgres://wagtail:changeme@postgres/wagtail
+      DATABASE_URL: postgres://wagtail:changeme@db/wagtail
       PYTHONPATH: /code/wagtail:/code/bakerydemo:$PYTHONPATH
     depends_on:
       - db

--- a/setup.sh
+++ b/setup.sh
@@ -32,3 +32,16 @@ if [ ! -d "libs/Willow" ]; then
 else
     echo Directory libs/Willow already exists, skipping...
 fi
+
+
+# Set up bakerydemo to use the Postgres database in the sister container
+if [ ! -f bakerydemo/bakerydemo/settings/local.py ]; then
+    echo "Creating local settings file"
+    cp bakerydemo/bakerydemo/settings/local.py.docker-compose-example bakerydemo/bakerydemo/settings/local.py
+fi
+
+# Create a blank .env file in bakerydemo to keep its settings files from complaining
+if [ ! -f bakerydemo/.env ]; then
+    echo "Creating file for local environment variables"
+    echo "DJANGO_SETTINGS_MODULE=bakerydemo.settings.local" > bakerydemo/.env
+fi


### PR DESCRIPTION
Added instructions on getting bakerydemo to use the PostgreSQL database from the adjacent container. Also includes how to recognize (and fix) problems due to model changes in wagtail's master branch.

This PR depends on a PR for bakerydemo https://github.com/wagtail/bakerydemo/pull/274