### PR TITLE
Drop unnecessary user from web container

### DIFF
--- a/docker-compose.linux.yml
+++ b/docker-compose.linux.yml
@@ -1,9 +1,6 @@
 version: '3'
 
 services:
-  web:
-    user: ${CURRENT_UID}
-
   frontend:
     user: ${CURRENT_UID}
 


### PR DESCRIPTION
This PR is an addition to https://github.com/wagtail/docker-wagtail-develop/pull/10 (where built files where not owned by user under Linux).

It turns out that the web container does not need the additional user, only the frontend container. This PR fixes this.