### PR TITLE
Add command for updating repos

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -e
+
+CURRENT_DIR=$PWD
+
+echo "Updating bakerydemo"
+cd $CURRENT_DIR/bakerydemo && git pull --rebase
+
+echo "Updating wagtail"
+cd $CURRENT_DIR/wagtail && git pull --rebase
+
+echo "Updating django-modelcluster"
+cd $CURRENT_DIR/libs/django-modelcluster && git pull --rebase
+
+echo "Updating Willow"
+cd $CURRENT_DIR/libs/Willow && git pull --rebase


### PR DESCRIPTION
This PR introduces a complementary bash script called `update.sh` which makes sure the development environment is up to date by going through the 4 different repos and updating them using `git pull --rebase`.