### PR TITLE
Reworked the database and Wagtail installation setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,8 @@
-# Don't copy the git repo, the compiled node_modules, or anything else that isn't needed into docker image.
+# Don't copy the git repos, the compiled node_modules, or anything else that isn't needed into the docker image.
 # This greatly speeds up re-building the image.
-.git
-wagtail/node_modules
-Dockerfile
-docker-compose.yml
-Procfile
-Vagrantfile
+**/.git
+**/node_modules
+**/Dockerfile
+**/docker-compose.yml
+**/Procfile
+**/Vagrantfile

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+# Don't copy the git repo, the compiled node_modules, or anything else that isn't needed into docker image.
+# This greatly speeds up re-building the image.
+.git
+wagtail/node_modules
+Dockerfile
+docker-compose.yml
+Procfile
+Vagrantfile

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 wagtail
 bakerydemo
 libs
-
+.idea
 .DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,18 @@ LABEL maintainer="hello@wagtail.io"
 # Set environment varibles
 ENV PYTHONUNBUFFERED 1
 
-RUN apt-get update -y && apt-get install -y libenchant-dev
+# Install libenchant and create the requirements folder.
+RUN apt-get update -y \
+    && apt-get install -y libenchant-dev \
+    && mkdir -p /code/requirements
 
-RUN mkdir -p /code/requirements
-COPY ./bakerydemo/requirements/base.txt /code/requirements/base.txt
-COPY ./bakerydemo/requirements/production.txt /code/requirements/production.txt
+# Install the bakerydemo project's dependencies into the image.
+COPY ./bakerydemo/requirements/* /code/requirements/
+RUN pip install --upgrade pip \
+    && pip install -r /code/requirements/production.txt
 
-RUN pip install --upgrade pip
-RUN pip install -r /code/requirements/production.txt
+# Install wagtail from the host. This folder will be overriteen by a volume mount during run time (so that code
+# changes show up immediately), but it also needs to be copied into the image now so that wagtail can be pip install'd.
+COPY ./wagtail /code/wagtail/
+RUN cd /code/wagtail/ \
+    && pip install -e .[testing,docs]

--- a/README.md
+++ b/README.md
@@ -37,10 +37,12 @@ Here is the resulting folder structure:
 └── bakerydemo    # Wagtail Bakery project used for development.
 ```
 
-Once setup is over,
+Once the build is complete:
 
 ```sh
-# 6. Start your container setup
+# 6. Run one-time databse setup, which will be persisted across container executions by Docker's Volumes system
+setup-db.sh
+# 7. Start your container setup
 docker-compose up
 # Success!
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,31 +5,23 @@ volumes:
 
 services:
   web:
+    container_name: "web"
     build: ./
     working_dir: /code/bakerydemo
-    command:
-      - /bin/bash
-      - -c
-      - |
-        cd /code/wagtail
-        pip install -e .[testing,docs]
-        cd /code/bakerydemo
-        python manage.py migrate --noinput
-        python manage.py load_initial_data
-        python manage.py update_index
-        python manage.py runserver 0.0.0.0:8000
+    command: ./manage.py runserver 0.0.0.0:8000
     volumes:
       - ./wagtail:/code/wagtail:delegated,rw
       - ./bakerydemo:/code/bakerydemo:delegated,rw
     ports:
       - "8000:8000"
     environment:
-      DATABASE_URL: postgres://wagtail:changeme@postgres/wagtail
+      DATABASE_URL: postgres://wagtail:changeme@db/wagtail
       PYTHONPATH: /code/wagtail:/code/bakerydemo:$PYTHONPATH
     depends_on:
       - db
       - frontend
   db:
+    container_name: "db"
     image: postgres:12.3-alpine
     environment:
       POSTGRES_USER: wagtail
@@ -41,6 +33,7 @@ services:
     expose:
       - "5432"
   frontend:
+    container_name: "frontend"
     build:
       context: .
       dockerfile: Dockerfile.frontend
@@ -51,5 +44,5 @@ services:
       - /bin/sh
       - -c
       - |
-        cp -r /node_modules /code/wagtail
+        cp -ru /node_modules /code/wagtail
         npm run start

--- a/setup-db.sh
+++ b/setup-db.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Fail if any command fails.
+set -e
+
+docker-compose exec web ./manage.py migrate --noinput
+docker-compose exec web ./manage.py load_initial_data
+docker-compose exec web ./manage.py update_index


### PR DESCRIPTION
In order to improve the development experience while using docker-wagtail-develop, I reorganized how the database setup is done, and how and when Wagtail gets installed into the python environment inside the docker container. Plus a few other changes.

1. Database. The migration and initial data load steps are now done once, by the user, during initial setup (setup-db.sh), rather than happening at the start of every `docker-compose up`. This is possible because the postgres data is already being stored in a Docker Volume, so it persists across container executions.

2. Wagtail is now installed into the `web` docker container by the Dockerfile, rather than docker-compose. This lets Docker skip that step if nothing has changed in Wagtail since the last build (admittedly, not super common, given that this project is for developing Wagtail), and generally makes the whole process a lot cleaner.

3. I added a bunch of stuff to .dockerignore, which significantly cuts down on the `web` and `frontend` images file sizes and build times.

4. I gave each of the three containers specific names, so that they can be more easily `exec`'d into for things like running `manage.py` commands or other OS stuff. This resulted in the connect string for the postgres DB needing to be tweaked.

5. I changed the `frontend` container's copy command for the node_modules folder to use the `-u` flag, which allows `cp` to skip any files that haven't changed since the last time the copy was run. This *dramatically* speeds up the startup of the `frontend` container (~1 minute down to as little as 5 seconds) on all but the very first execution (which does the initial copy into the host's wagtail folder).

I really wanted to find a way to put node_modules into a Docker Volume, but you can't write to Volumes during the image build process, which negates all the value I could think of from doing that. I also considered mounting a Volume into `/code/wagtail/node_modules` on both the `web` and `frontend` containers, but since we'd still need to run the copy operation to put `node_modules` into the Volume, it didn't seem like that actually added anything of value compared to how it's already being done.

And btw, if you're developing on a Mac, I *strongly* recommend installing Docker v2.3.4.0. It's the sole version that uses the "mutagen" file mount system instead of Docker's old "osxfs" and their new "gRPC-FUSE", and mutagen is like 10-20 times faster than both of them. Fast file system access is pretty important for this project, since we do so much file system mounting. This dramatically improves the performance of *everything* that happens inside the containers, including the file copy and asset build done in the `frontend` and the performance of browsing the site.