### PR TITLE
Clean up front-end container Dockerfile

### DIFF
--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -1,8 +1,6 @@
 FROM node:10-slim
 LABEL maintainer="hello@wagtail.io"
 
-COPY ./wagtail/package.json ./package.json
+COPY ./wagtail/package.json ./wagtail/package-lock.json ./
 
-RUN npm i npm@latest -g
 RUN npm --prefix / install
-RUN npm install npm-run-all gulp webpack /


### PR DESCRIPTION
This contains three different changes:

- The COPY step was missing the lockfile. While I don’t necessarily think this was a blocker, it’s good to have reproducible builds.
- We shouldn’t need the "latest" npm. Wagtail’s development setup with Vagrant uses the version of npm shipped with the latest Node 10. If we keep `latest`, we’re going to run into issues when npm releases breaking changes, like with npm v7.
- `npm-run-all`, `gulp`, `webpack` are all dependencies of Wagtail and shouldn’t need to be installed separately.

In addition to the above, I’m a bit concerned about this part of the setup:

https://github.com/wagtail/docker-wagtail-develop/blob/8b8d78f3ccd938054772a525b9a21c67f325907b/docker-compose.yml#L43-L48

This resets whatever dependencies people might have installed with the stale dependencies from their last image build, on every container start. This feels like it’s going to cause a lot of pain, as this isn’t really the behavior you’d expect from a development environment.