### PR TITLE
Add VSCode dev container configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,20 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.163.1/containers/docker-existing-docker-compose
+// If you want to run as a non-root user in the container, see .devcontainer/docker-compose.yml.
+{
+    "name": "Existing Docker Compose (Extend)",
+    "dockerComposeFile": [
+        "../docker-compose.yml",
+        "docker-compose.yml"
+    ],
+    "service": "web",
+    "workspaceFolder": "/code",
+    "settings": {
+        "terminal.integrated.shell.linux": "bash",
+        "python.pythonPath": "/usr/local/bin/python"
+    },
+    "extensions": [
+        "ms-python.python",
+        "editorconfig.editorconfig"
+    ]
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,7 @@
+services:
+  web:
+    volumes:
+      - ./.vscode:/code/.vscode:delegated,rw
+
+    # Overrides default command so things don't shut down after the process ends.
+    command: /bin/sh -c "while sleep 1000; do :; done"

--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,5 @@
 **/docker-compose.yml
 **/Procfile
 **/Vagrantfile
+**/.devcontainer
+**/.vscode

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+      {
+        "name": "Python: Django",
+        "type": "python",
+        "request": "launch",
+        "program": "${workspaceFolder}/bakerydemo/manage.py",
+        "args": ["runserver", "0.0.0.0:8000"],
+        "django": true,
+        "justMyCode": false,
+        "cwd": "${workspaceFolder}/bakerydemo/"
+      }
+    ]
+  }

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ If you're running this on Linux you might get into some privilege issues that ca
 CURRENT_UID=$(id -u):$(id -g) docker-compose -f docker-compose.yml -f docker-compose.linux.yml up
 ```
 
+Alternatively, if you're using VSCode and have the "Remote - Containers" extension, you can open the command palette and select "Remote Containers - Reopen in Container" to attach VSCode to the container. This allows for much deeper debugging.
+
 - Visit your site at http://localhost:8000
 - The admin interface is at http://localhost:8000/admin/ - log in with `admin` / `changeme`.
 


### PR DESCRIPTION
Add a vscode dev container configuration for in-depth debugging.

Whilst this configuration exists, it shouldn't impact or change anything about existing users or those who do not use VSCode.

Definitely recommend someone more familiar with this repo's setup give it a try, to double check it works and doesn't break existing flows.

See also https://git.torchbox.com/internal/wagtail-kit/-/merge_requests/604.