### PR TITLE
Improving the frontend initial build

### DIFF
--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -3,4 +3,4 @@ LABEL maintainer="hello@wagtail.io"
 
 COPY ./wagtail/package.json ./wagtail/package-lock.json ./
 
-RUN npm --prefix / install
+RUN npm --prefix / install --loglevel info

--- a/README.md
+++ b/README.md
@@ -29,7 +29,13 @@ Without this step wagtail>node_modules and wagtail>wagtail>admin/static dont't e
 # 4.1 
 docker-compose run frontend 
 ```
-When this finishes (which can take a while) terminate it (ctrl-c) before running the next step. Ideally also run docker-compose down to remove the conatiner as it's no longer needed
+When this finishes (which can take a while) terminate it (ctrl-c) before running the next step.
+
+You should see something like
+```
+webpack compiled successfully in 52229 ms
+```
+Ideally also run docker-compose down to remove the conatiner as it's no longer needed.
 
 ### Build all the containers
 ```sh

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ docker-compose run frontend
 ```
 When this finishes (which can take a while) terminate it (ctrl-c) before running the next step. Ideally also run docker-compose down to remove the conatiner as it's no longer needed
 
+### Build all the containers
 ```sh
 # 5. Build the containers
 docker-compose build

--- a/README.md
+++ b/README.md
@@ -22,6 +22,16 @@ git clone git@github.com:wagtail/docker-wagtail-develop.git wagtail-dev
 cd wagtail-dev/
 # 4. Run the setup script. This will check out the bakerydemo project and local copies of wagtail and its dependencies.
 ./setup.sh
+```
+### Build a temporary frontend container.
+Without this step wagtail>node_modules and wagtail>wagtail>admin/static dont't exist when running the build step and are not added to the final image. (Wagtail admin will be missing the required css and js files)
+```sh
+# 4.1 
+docker-compose run frontend 
+```
+When this finishes (which can take a while) terminate it (ctrl-c) before running the next step. Ideally also run docker-compose down to remove the conatiner as it's no longer needed
+
+```sh
 # 5. Build the containers
 docker-compose build
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: "3"
 
 volumes:
   postgres-data:
@@ -44,5 +44,6 @@ services:
       - /bin/sh
       - -c
       - |
+        echo "This process can take a long time to complete..."
         cp -ru /node_modules /code/wagtail
         npm run start


### PR DESCRIPTION
When initialising the project the admin assets are missing to start with.

https://github.com/wagtail/docker-wagtail-develop/issues/23 and possibly this issue https://github.com/wagtail/wagtail/issues/6877

So I found you can avoid this by building the frontend on it's own first before running the full build. 
```docker-compose run frontend```

This adds some extra feedback (Dockerfile.frontend and docker-compose.yml) in the console while building the frontend as it takes a while to complete.

When you run the full build in step 5 
```docker-compose build```
the assets are in place ready to be copied into the image.