### PR TITLE
Update Dockerfile for Debian Bullseye release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use an official Python runtime as a parent image
-FROM python:3.7-bullseye
+FROM python:3.8-bullseye
 LABEL maintainer="hello@wagtail.io"
 
 # Set environment varibles

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use an official Python runtime as a parent image
-FROM python:3.7
+FROM python:3.7-bullseye
 LABEL maintainer="hello@wagtail.io"
 
 # Set environment varibles
@@ -7,7 +7,7 @@ ENV PYTHONUNBUFFERED 1
 
 # Install libenchant and create the requirements folder.
 RUN apt-get update -y \
-    && apt-get install -y libenchant-dev postgresql-client \
+    && apt-get install -y libenchant-2-dev postgresql-client \
     && mkdir -p /code/requirements
 
 # Install the bakerydemo project's dependencies into the image.


### PR DESCRIPTION
The previously used base image `python:3.7` was changed to now use
Debian Bullseye. This lead to installation issues of `libenchant-dev`
(see #31).

This is now fixed by upgrading the installation command for `libenchant`
to `libenchant-2-dev` (see also https://pkgs.org/search/?q=LIBENCHANT).

Additionally, to avoid similar issues in the future, the Debian version
of the base image is now defined in the `Dockerfile`.

Closes #31 