### PR TITLE
Enclose strings in quotes to avoid syntax errors in YAML parsing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,8 +16,8 @@ services:
     ports:
       - "8000:8000"
     environment:
-      DATABASE_URL: postgres://wagtail:changeme@db/wagtail
-      PYTHONPATH: /code/wagtail:/code/bakerydemo:$PYTHONPATH
+      DATABASE_URL: "postgres://wagtail:changeme@db/wagtail"
+      PYTHONPATH: "/code/wagtail:/code/bakerydemo:$PYTHONPATH"
     depends_on:
       - db
       - frontend


### PR DESCRIPTION
Specifically the error yaml: line 20: mapping values are not allowed in this context