### PR TITLE
Improved the speed of the frontend build.

### DIFF
--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -1,6 +1,7 @@
 FROM node:14-slim
 LABEL maintainer="hello@wagtail.io"
 
+RUN apt-get update && apt-get install rsync -y
 COPY ./wagtail/package.json ./wagtail/package-lock.json ./
 
-RUN npm --prefix / install
+RUN npm --prefix / install --loglevel info

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,8 @@ version: '3'
 
 volumes:
   postgres-data:
-
+  node_modules:
+  
 services:
   web:
     container_name: "web"
@@ -13,6 +14,7 @@ services:
     volumes:
       - ./wagtail:/code/wagtail:delegated,rw
       - ./bakerydemo:/code/bakerydemo:delegated,rw
+      - node_modules:/code/wagtail/node_modules/
     ports:
       - "8000:8000"
     environment:
@@ -41,10 +43,7 @@ services:
     working_dir: /code/wagtail
     volumes:
       - ./wagtail:/code/wagtail:delegated,rw
-    command:
-      - /bin/sh
-      - -c
-      - |
-        cp -ru /node_modules /code/wagtail
-        npm run start
+      - node_modules:/code/wagtail/node_modules/
+    command: bash -c "echo 'Copying node_modules, this may take a few minutes...' && rsync -rah --info=progress2 /node_modules /code/wagtail/ && npm run start"
     restart: "no"
+    tty: true


### PR DESCRIPTION
This PR improves the speed of the frontend build dramatically. The single most effective part of this fix is to exclude the node_modules folder from the shared volume. Also added rsync for copying the node_modules folder to get a more verbose feedback on the progress.