### PR TITLE
Add makefile for docker commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,17 +13,17 @@ ssh: ## Enter the running backend Docker container for the wagtail bakery site
 ssh-shell: ## Enter the running Docker container shell
 	docker-compose exec web python manage.py shell
 
-ssh-frontend: ## Enter the running Docker container shell
+ssh-fe: ## Open a shell to work with the frontend code (Node/NPM)
 	docker-compose exec frontend bash
 
 ssh-wagtail: ## Enter the running Docker container for the wagtail development environment
 	docker-compose exec -w /code/wagtail web bash
 
+ssh-db: ## Open a PostgreSQL shell session
+	docker-compose exec web python manage.py dbshell
+
 clean: ## Stop and remove all Docker containers
 	docker-compose down
-
-run-tests: ## Stop and remove all Docker containers
-	docker-compose exec -w /code/wagtail web python runtests.py
 
 migrations: ## Make migrations to the wagtail bakery site
 	docker-compose exec web python manage.py makemigrations

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ build: ## Build the backend Docker image
 up: ## Bring the backend Docker container up
 	docker-compose up
 
-down: ## Stop the backend Docker container
+stop: ## Stop the backend Docker container
 	docker-compose stop
 
 ssh: ## Enter the running backend Docker container for the wagtail bakery site
@@ -22,7 +22,7 @@ ssh-wagtail: ## Enter the running Docker container for the wagtail development e
 ssh-db: ## Open a PostgreSQL shell session
 	docker-compose exec web python manage.py dbshell
 
-clean: ## Stop and remove all Docker containers
+down: ## Stop and remove all Docker containers
 	docker-compose down
 
 migrations: ## Make migrations to the wagtail bakery site

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,35 @@
+build: ## Build the backend Docker image
+	docker-compose build web
+
+up: ## Bring the backend Docker container up
+	docker-compose up
+
+down: ## Stop the backend Docker container
+	docker-compose stop
+
+ssh: ## Enter the running backend Docker container for the wagtail bakery site
+	docker-compose exec web bash
+
+ssh-shell: ## Enter the running Docker container shell
+	docker-compose exec web python manage.py shell
+
+ssh-frontend: ## Enter the running Docker container shell
+	docker-compose exec frontend bash
+
+ssh-wagtail: ## Enter the running Docker container for the wagtail development environment
+	docker-compose exec -w /code/wagtail web bash
+
+clean: ## Stop and remove all Docker containers
+	docker-compose down
+
+run-tests: ## Stop and remove all Docker containers
+	docker-compose exec -w /code/wagtail web python runtests.py
+
+migrations: ## Make migrations to the wagtail bakery site
+	docker-compose exec web python manage.py makemigrations
+
+migrate: ## Migrate the wagtail bakery site migrations
+	docker-compose exec web python manage.py migrate
+
+test: ## Run all wagtail tests or pass in a file with `make test file=wagtail.admin.tests.test_name.py`
+	docker-compose exec -w /code/wagtail web python runtests.py $(FILE)

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,16 @@
+.PHONY: help
+.DEFAULT_GOAL := help
+
+help: ## ⁉️ - Display help comments for each make command
+	@grep -E '^[0-9a-zA-Z_-]+:.*? .*$$'  \
+		$(MAKEFILE_LIST)  \
+		| awk 'BEGIN { FS=":.*?## " }; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'  \
+		| sort
+
 build: ## Build the backend Docker image
 	docker-compose build web
 
-up: ## Bring the backend Docker container up
+start: ## Bring the backend Docker container up
 	docker-compose up
 
 stop: ## Stop the backend Docker container

--- a/README.md
+++ b/README.md
@@ -87,17 +87,20 @@ web        ./manage.py runserver 0.0. ...   Up          0.0.0.0:8000->8000/tcp
 ```
 
 ### Build the backend Docker image
-```
+
+```sh
 make build
 ```
 
 ### Bring the backend Docker container up
-```
+
+```sh
 make up
 ```
 
 ### Stop the backend Docker container
-```
+
+```sh
 make down
 ```
 	
@@ -109,7 +112,7 @@ make test
 
 ### Run tests for a specific file
 
-```
+```sh
 make test file=wagtail.admin.tests.test_name.py
 ```
 
@@ -145,13 +148,13 @@ make ssh-fe
 
 ### Make migrations to the wagtail bakery site
 
-```
+```sh
 make migrations
 ```
 
 ### Migrate the wagtail bakery site
 
-```
+```sh
 make migrate
 ```
 

--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ make migrations
 make migrate
 ```
 
+Getting ready to contribute
 ---------------------------
 
 Here are other actions you will likely need to do to make your first contribution to Wagtail.

--- a/README.md
+++ b/README.md
@@ -86,37 +86,75 @@ frontend   docker-entrypoint.sh /bin/ ...   Up
 web        ./manage.py runserver 0.0. ...   Up          0.0.0.0:8000->8000/tcp
 ```
 
+### Build the backend Docker image
+```
+make build
+```
+
+### Bring the backend Docker container up
+```
+make up
+```
+
+### Stop the backend Docker container
+```
+make down
+```
+	
 ### Run tests
 
 ```sh
-docker-compose exec -w /code/wagtail web python runtests.py
+make test
+```
+
+### Run tests for a specific file
+
+```
+make test file=wagtail.admin.tests.test_name.py
 ```
 
 ### Open a Django shell session
 
 ```sh
-docker-compose exec web python manage.py shell
+make ssh-shell
 ```
 
 ### Open a PostgreSQL shell session
 
 ```sh
-docker-compose exec web python manage.py dbshell
+make ssh-db
 ```
 
 ### Open a shell on the web server
 
 ```sh
-docker-compose exec web bash
+make ssh
 ```
 
 ### Open a shell to work with the frontend code (Node/NPM)
 
 ```sh
-docker-compose exec frontend bash
+make ssh-fe
 ```
 
-Getting ready to contribute
+### Open a shell to work with the frontend code (Node/NPM)
+
+```sh
+make ssh-fe
+```
+
+### Make migrations to the wagtail bakery site
+
+```
+make migrations
+```
+
+### Migrate the wagtail bakery site
+
+```
+make migrate
+```
+
 ---------------------------
 
 Here are other actions you will likely need to do to make your first contribution to Wagtail.

--- a/README.md
+++ b/README.md
@@ -90,11 +90,19 @@ web        ./manage.py runserver 0.0. ...   Up          0.0.0.0:8000->8000/tcp
 ```sh
 make build
 ```
+or
+```sh
+docker-compose build web
+```
 
 ### Bring the backend Docker container up
 
 ```sh
 make start
+```
+or
+```sh
+docker-compose up
 ```
 
 ### Stop all Docker containers
@@ -102,11 +110,18 @@ make start
 ```sh
 make stop
 ```
-
+or
+```sh
+docker-compose stop
+```
 ### Stop all and remove all Docker containers
 
 ```sh
 make down
+```
+or
+```sh
+docker-compose down
 ```
 	
 ### Run tests
@@ -114,11 +129,19 @@ make down
 ```sh
 make test
 ```
+or
+```sh
+docker-compose exec -w /code/wagtail web python runtests.py
+```
 
 ### Run tests for a specific file
 
 ```sh
 make test file=wagtail.admin.tests.test_name.py
+```
+or
+```sh
+docker-compose exec -w /code/wagtail web python runtests.py wagtail.admin.tests.{test_file_name_here}.py
 ```
 
 ### Open a Django shell session
@@ -126,29 +149,48 @@ make test file=wagtail.admin.tests.test_name.py
 ```sh
 make ssh-shell
 ```
+or
+```sh
+docker-compose exec web python manage.py shell
+```
 
 ### Open a PostgreSQL shell session
 
 ```sh
 make ssh-db
 ```
-
+or
+```sh
+docker-compose exec web python manage.py dbshell
+```
 ### Open a shell on the web server
 
 ```sh
 make ssh
 ```
-
-### Open a shell to work with the frontend code (Node/NPM)
-
+or
 ```sh
-make ssh-fe
+docker-compose exec web bash
 ```
 
 ### Open a shell to work with the frontend code (Node/NPM)
 
 ```sh
 make ssh-fe
+```
+or
+```sh
+docker-compose exec frontend bash
+```
+
+### Open a shell to work within the wagtail container
+
+```sh
+make ssh-fe
+```
+or
+```sh
+docker-compose exec -w /code/wagtail web bash
 ```
 
 ### Make migrations to the wagtail bakery site
@@ -156,11 +198,19 @@ make ssh-fe
 ```sh
 make migrations
 ```
+or
+```sh
+docker-compose exec web python manage.py makemigrations
+```
 
 ### Migrate the wagtail bakery site
 
 ```sh
 make migrate
+```
+or
+```sh
+docker-compose exec web python manage.py migrate
 ```
 
 Getting ready to contribute

--- a/README.md
+++ b/README.md
@@ -87,7 +87,6 @@ web        ./manage.py runserver 0.0. ...   Up          0.0.0.0:8000->8000/tcp
 ```
 
 ### Build the backend Docker image
-
 ```sh
 make build
 ```
@@ -95,10 +94,16 @@ make build
 ### Bring the backend Docker container up
 
 ```sh
-make up
+make start
 ```
 
-### Stop the backend Docker container
+### Stop all Docker containers
+
+```sh
+make stop
+```
+
+### Stop all and remove all Docker containers
 
 ```sh
 make down


### PR DESCRIPTION
This PR is for the lazy people like me. It is for the creation of a makefile for the docker compose commands. This will simplify the commands that you need to enter when working with the docker environment. For example running tests becomes 
```
make test
```
which was 
```
docker-compose exec -w /code/wagtail web python runtests.py
```

This PR also updates the readme to use those commands instead of the longer versions of them. 