### PR TITLE
fix typo in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,6 @@ RUN cd /code/wagtail/ \
 
 # Install Willow from the host. This folder will be overwritten by a volume mount during run time (so that code
 # changes show up immediately), but it also needs to be copied into the image now so that Willow can be pip install'd.
-COPY ./libs/willow /code/willow/
+COPY ./libs/Willow /code/willow/
 RUN cd /code/willow/ \
     && pip install -e .[testing]


### PR DESCRIPTION
There is a typo in Dockerfile at `COPY ./libs/willow /code/willow/` command. The actual name of directory is Willow (capital 'W') which was causing this command to fail.