### PR TITLE
Ensure that `file=` will actually work when passing into make test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,4 +41,4 @@ migrate: ## Migrate the wagtail bakery site migrations
 	docker-compose exec web python manage.py migrate
 
 test: ## Run all wagtail tests or pass in a file with `make test file=wagtail.admin.tests.test_name.py`
-	docker-compose exec -w /code/wagtail web python runtests.py $(FILE)
+	docker-compose exec -w /code/wagtail web python runtests.py $(file) $(FILE)


### PR DESCRIPTION
- Fixes #48
- Support both `FILE=` and `file=`


## Validation logs

```
➜ make test file=wagtail.admin.tests.test_workflows
docker-compose exec -w /code/wagtail web python runtests.py wagtail.admin.tests.test_workflows 
WARN[0000] The "PYTHONPATH" variable is not set. Defaulting to a blank string. 
Found 88 test(s).
Creating test database for alias 'default'...
```