### PR TITLE
Add bakerydemo local settings example file and fix setup script accordingly (#54)

### DIFF
--- a/bakerydemo-settings-local.py.example
+++ b/bakerydemo-settings-local.py.example
@@ -1,0 +1,6 @@
+from bakerydemo.settings.dev import *  # noqa
+import dj_database_url
+
+# Override settings here
+db_from_env = dj_database_url.config(conn_max_age=500)
+DATABASES['default'].update(db_from_env)

--- a/setup.sh
+++ b/setup.sh
@@ -37,7 +37,7 @@ fi
 # Set up bakerydemo to use the Postgres database in the sister container
 if [ ! -f bakerydemo/bakerydemo/settings/local.py ]; then
     echo "Creating local settings file"
-    cp bakerydemo/bakerydemo/settings/local.py.docker-compose-example bakerydemo/bakerydemo/settings/local.py
+    cp bakerydemo-settings-local.py.example bakerydemo/bakerydemo/settings/local.py
 fi
 
 # Create a blank .env file in bakerydemo to keep its settings files from complaining


### PR DESCRIPTION
As discussed in issue #54, the goal of this PR is to fix the `setup.sh` script, which currently attempts to copy a file that does not exist anymore (due to [this PR](https://github.com/wagtail/bakerydemo/pull/393) in the `bakerydemo` repo).

We create an example file with the proper content at the root of the repo and update the `setup.sh` script accordingly.

To test that this worked properly, I ran the modified version of the `setup.sh` script and I was able to see that the right file was created in the `bakerydemo/bakerydemo/settings` folder. The error message mentioned in #54 didn't appear anymore. I followed the rest of the [regular setup instructions](https://github.com/wagtail/docker-wagtail-develop#setup) and I was able to boot an instance of `bakerydemo`.