### PR TITLE
Remove TODO from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,10 +235,3 @@ Contributing to Willow
 
 You can use the same setup to contribute to Willow.
 You simply do the same operations to fork the Willow project and point your local copy of Willow to your fork.
-
-
-TODO
-----
-
-* Set up an elasticsearch service container
-* Test on Windows and Linux


### PR DESCRIPTION
- This is function on Windows & Linux, bugs can be raised if needed, see related #46 #35 #31 (all closed)
- Elasticsearch/Opensearch Docker container is already an issue #3 (still open)