### PR TITLE
Update README.md (include link to Vagrant develop)

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,3 +284,7 @@ git pull --all
 
 You can use the same setup to contribute to Willow.
 You simply do the same operations to fork the Willow project and point your local copy of Willow to your fork.
+
+## See also
+
+- [Vagrant Wagtail development](https://github.com/wagtail/vagrant-wagtail-develop)


### PR DESCRIPTION
Include cross-reference to Wagtail's Vagrant development setup. Useful for those that get stuck with / cannot use Docker.

See related https://github.com/wagtail/vagrant-wagtail-develop/pull/35