### PR TITLE
Remove uninterpreted environment variable from `docker-compose.yml`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       - "8000:8000"
     environment:
       DATABASE_URL: "postgres://wagtail:changeme@db/wagtail"
-      PYTHONPATH: "/code/wagtail:/code/bakerydemo:$PYTHONPATH"
+      PYTHONPATH: "/code/wagtail:/code/bakerydemo"
     depends_on:
       - db
       - frontend


### PR DESCRIPTION
This caused a spurious warning when running `docker compose` commands because `$PYTHONPATH` is not defined on the docker _host_ and docker attempted to interpret it as if it were any other environment variable e.g. `$DB_USER`, etc.

All it accomplished was to add a non-existent directory to the path:

```bash
docker compose run web bash
root@2bc54a69fd5c:/code/bakerydemo# echo $PYTHONPATH
/code/wagtail:/code/bakerydemo:$PYTHONPATH

root@2bc54a69fd5c:/code/bakerydemo# python -c "import sys; print('\n'.join(sys.path))"

/code/wagtail
/code/bakerydemo
/code/bakerydemo/$PYTHONPATH
/usr/local/lib/python38.zip
/usr/local/lib/python3.8
/usr/local/lib/python3.8/lib-dynload
/usr/local/lib/python3.8/site-packages
/code/willow
```

Fixes #56