### PR TITLE
Removed `bakerydemo-settings-local.py.example`

### DIFF
--- a/bakerydemo-settings-local.py.example
+++ b/bakerydemo-settings-local.py.example
@@ -1,6 +1,0 @@
-from bakerydemo.settings.dev import *  # noqa
-import dj_database_url
-
-# Override settings here
-db_from_env = dj_database_url.config(conn_max_age=500)
-DATABASES['default'].update(db_from_env)

--- a/setup.sh
+++ b/setup.sh
@@ -37,11 +37,11 @@ fi
 # Set up bakerydemo to use the Postgres database in the sister container
 if [ ! -f bakerydemo/bakerydemo/settings/local.py ]; then
     echo "Creating local settings file"
-    cp bakerydemo-settings-local.py.example bakerydemo/bakerydemo/settings/local.py
+    cp bakerydemo/bakerydemo/settings/local.py.example bakerydemo/bakerydemo/settings/local.py
 fi
 
 # Create a blank .env file in bakerydemo to keep its settings files from complaining
 if [ ! -f bakerydemo/.env ]; then
     echo "Creating file for local environment variables"
-    echo "DJANGO_SETTINGS_MODULE=bakerydemo.settings.local" > bakerydemo/.env
+    echo "DJANGO_SETTINGS_MODULE=bakerydemo.settings.dev" > bakerydemo/.env
 fi


### PR DESCRIPTION
This file never worked, it caused a circular import loop since it attempts to `from bakerydemo.settings.dev import *` but the dev settings does:

```python
try:
    from .local import *  # noqa
except ImportError:
    pass
```

Fixed the `setup.sh` script to set the correct settings module environment variable

Fixes #68