### PR TITLE
Remove obsolete `version` attribute in docker compose

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,9 +1,7 @@
-version: '3'
-
 volumes:
   postgres-data:
   node_modules:
-  
+
 services:
   web:
     container_name: "web"


### PR DESCRIPTION
Avoid warning when setting up.

> compose.yaml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion