### PR TITLE
Update to Node 22 (active LTS)

### DIFF
--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -1,4 +1,4 @@
-FROM node:20-slim
+FROM node:22-slim
 LABEL maintainer="hello@wagtail.org"
 
 RUN apt-get update && apt-get install rsync make -y


### PR DESCRIPTION
- See https://nodejs.org/en/blog/release/v22.11.0
- See https://github.com/wagtail/wagtail/issues/12531
- See https://github.com/wagtail/docker-wagtail-develop/pull/73 (previous update for reference)
- See equivalent PR on Vagrant https://github.com/wagtail/vagrant-wagtail-develop/pull/40