### PR TITLE
run tests in parallel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ migrate: ## Migrate the wagtail bakery site migrations
 	docker compose exec web python manage.py migrate
 
 test: ## Run all wagtail tests or pass in a file with `make test file=wagtail.admin.tests.test_name`
-	docker compose exec -w /code/wagtail web python runtests.py $(file) $(FILE)
+	docker compose exec -w /code/wagtail web python runtests.py $(file) $(FILE) --parallel
 
 format-wagtail: ## Format Wagtail repo
 	docker compose exec -w /code/wagtail web make format-server

--- a/Makefile
+++ b/Makefile
@@ -41,8 +41,11 @@ migrate: ## Migrate the wagtail bakery site migrations
 	docker compose exec web python manage.py migrate
 
 test: ## Run all wagtail tests or pass in a file with `make test file=wagtail.admin.tests.test_name`
-	docker compose exec -w /code/wagtail web python runtests.py $(file) $(FILE) --parallel
+	docker compose exec -w /code/wagtail web python runtests.py $(file) $(FILE)
 
+test-parallel: ## Same as make test but will run tests in parallel
+	docker compose exec -w /code/wagtail web python runtests.py $(file) $(FILE) --parallel
+	
 format-wagtail: ## Format Wagtail repo
 	docker compose exec -w /code/wagtail web make format-server
 	docker compose exec frontend make format-client

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ migrate: ## Migrate the wagtail bakery site migrations
 test: ## Run all wagtail tests or pass in a file with `make test file=wagtail.admin.tests.test_name`
 	docker compose exec -w /code/wagtail web python runtests.py $(file) $(FILE)
 
-test-parallel: ## Same as make test but will run tests in parallel
+test-parallel: ## Equivalent to make test, but runs tests in parallel
 	docker compose exec -w /code/wagtail web python runtests.py $(file) $(FILE) --parallel
 	
 format-wagtail: ## Format Wagtail repo

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ make test
 or
 
 ```sh
-docker compose exec -w /code/wagtail web python runtests.py
+docker compose exec -w /code/wagtail web python runtests.py --parallel
 ```
 
 ### Run tests for a specific file

--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ docker compose down
 ### Run tests
 
 ```sh
+# run make test-parallel for tests to run faster but error messages can be more cryptic
 make test
 ```
 


### PR DESCRIPTION
when I run `docker compose exec -w /code/wagtail web python runtests.py --parallel` the tests run significantly faster then when I run `docker compose exec -w /code/wagtail web python runtests.py` without `--parallel`.

CPU, Memory, and Disk usage appear to be approximately the same. So adding this to the make file would be a big win for me.