### PR TITLE
Updated Postgres container to Postgres 14

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,9 @@ ssh-wagtail: ## Enter the running Docker container for the wagtail development e
 ssh-db: ## Open a PostgreSQL shell session
 	docker compose exec web python manage.py dbshell
 
+destroy-db: ## Remove the volume containing the PostgreSQL data
+	docker volume rm docker-wagtail-develop_postgres-data
+
 down: ## Stop and remove all Docker containers
 	docker compose down
 

--- a/README.md
+++ b/README.md
@@ -264,6 +264,24 @@ or
 docker compose exec web python manage.py migrate
 ```
 
+### Destroy the current database volume
+
+If this project has changed database versions since you first started using it, you may need to
+delete the database volume and then recreate the bakerydemo data using the `setup-db.sh script`. To
+delete all the data from the database running in the `db` container, run the following commands:
+
+```sh
+make down
+make destroy-db
+```
+
+or
+
+```sh
+docker compose down
+docker volume rm docker-wagtail-develop_postgres-data
+```
+
 ## Getting ready to contribute
 
 Here are other actions you will likely need to do to make your first contribution to Wagtail.

--- a/compose.yaml
+++ b/compose.yaml
@@ -24,7 +24,7 @@ services:
 
   db:
     container_name: "db"
-    image: postgres:14.1
+    image: postgres:14
     environment:
       POSTGRES_USER: wagtail
       POSTGRES_DB: wagtail

--- a/compose.yaml
+++ b/compose.yaml
@@ -21,9 +21,10 @@ services:
     depends_on:
       - db
       - frontend
+
   db:
     container_name: "db"
-    image: postgres:12.3-alpine
+    image: postgres:14.1
     environment:
       POSTGRES_USER: wagtail
       POSTGRES_DB: wagtail
@@ -33,6 +34,7 @@ services:
     restart: "no"
     expose:
       - "5432"
+
   frontend:
     container_name: "frontend"
     build:


### PR DESCRIPTION
Today I found I had to upgrade my Postgres version from 12 to 1. This is because bakerydemo is now running Django 5.1 which dropped support for postgres 12. Bakerydemo's own docker-compose.yml uses postgres 14.1 so I updated this to match.

This will be a breaking change for people with existing installs so I added a make target to remove the pg data volume and documented it in the README. 